### PR TITLE
Fix extra parenthesis in code

### DIFF
--- a/waybar-updates
+++ b/waybar-updates
@@ -59,7 +59,7 @@ function check_aur_updates() {
     tmp_aur_packages_file=$(mktemp --suffix -waybar-updates)
     # shellcheck disable=SC2046
     new_aur_packages=$(curl -s "https://aur.archlinux.org/rpc?v=5&type=info$(printf '&arg[]=%s' $(echo "$old_aur_packages" | cut -f1 -d' '))" |
-      jq -r '.results[] | .Name + " " + .Version' | tee "$tmp_aur_packages_file")
+      jq -r '.results[] | .Name + " " + .Version' | tee "$tmp_aur_packages_file"
   elif [ "$1" == "offline" ]; then
     new_aur_packages=$(cat "$tmp_aur_packages_file")
   fi


### PR DESCRIPTION
The following code line has an extra parenthesis at the end : 
https://github.com/L11R/waybar-updates/blob/81b2e6d1943472306c97f943377d2131a3491037/waybar-updates#L61-L62

When running the command manually in the terminal, we have the following error :
```
❯ curl -s "https://aur.archlinux.org/rpc?v=5&type=info$(printf '&arg[]=%s' $(echo "$(pacman -Qm)" | cut -f1 -d' '))" |
      jq -r '.results[] | .Name + " " + .Version' | tee "/tmp/tmp.aJLtzhPOGA-waybar-updates")
zsh: parse error near `)'
```

Removing the parenthesis fixes the issue :
```sh
❯ curl -s "https://aur.archlinux.org/rpc?v=5&type=info$(printf '&arg[]=%s' $(echo "$(pacman -Qm)" | cut -f1 -d' '))" |
      jq -r '.results[] | .Name + " " + .Version' | tee "/tmp/tmp.aJLtzhPOGA-waybar-updates"
archlinux-tweak-tool-git r976.2c1ea6e-1
bmap-tools 3.6-3
brillo 1.4.12-1
can-utils 2021.08.0-1
cider-bin 1.5.9-1
displaylink 5.7-1
dropbox 172.4.7555-1
evdi 1.13.1-2
f1multiviewer-bin 1.17.1-1
google-chrome 113.0.5672.92-1
hyprpicker-git r8.0fc1134-1
mailspring 1.10.8-1
ms-outlook-nativefier 0.01-1
nvm 0.39.3-1
oh-my-zsh-git r6192.be4a95297-1
picoscope7beta 7.0.121_1r14751-1
programmer-calculator 3.0-1
ps7b_libpicocv 1.1.33_beta2r167-1
ps7b_libpicoipp 1.4.0_4r157-1
ps7b_libps2000 3.0.110_3r3464-1
ps7b_libps2000a 2.1.110_5r3464-1
sddm-catppuccin-git r33.7b7a86e-1
sddm-git 0.19.0.170.g3e48649-1
sddm-sugar-candy-git r53.2b72ef6-1
slack-desktop 4.31.155-1
swaylock-effects-git r402.9ac172a-1
update-grub 0.0.1-7
visual-studio-code-bin 1.78.1-1
vtop 0.6.1-1
waybar-hyprland-git 0.9.17.r159.ga9a22234-1
waybar-module-pacman-updates-git 0.2.1-7
waybar-updates 0.2.1-1
whatsie 4.13.0-1
wlogout 1.1.1-3
wlr-randr 0.3.0-1
xdg-desktop-portal-hyprland-git 1:r261.e1f145d-4
yay-bin 12.0.4-1
zsh-thefuck-git r6.136b5a2-1
```

Closes #2