### PR TITLE
feat: remove temp files on exit

### DIFF
--- a/waybar-updates
+++ b/waybar-updates
@@ -96,12 +96,20 @@ function json() {
     '{"text": $text, "alt": $alt, "tooltip": $tooltip, "class": $class}'
 }
 
+function cleanup() {
+  echo "Cleaning up..."
+  rm -f "$tmp_aur_packages_file"
+  exit 0
+}
+
 # sync at the first start
 check_updates online
 pacman_updates_checksum=""
 aur_updates_checksum=""
 # count cycles to check updates using network sometime
 cycle=0
+
+trap cleanup SIGINT SIGTERM
 
 # check updates every 6 seconds
 while true; do


### PR DESCRIPTION
Currently if the process was interrupted, temp file with package list will leave. This patch should fix it. Part of the problem hightlighted in #2.

@julian-poidevin can you test it a bit?

I will prepare a new release if everything is okay.